### PR TITLE
✨ scaffold README and duckweed scooper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,63 @@
 # aquiloop
-Parametric aquarium tools in OpenSCAD for makers and 3D printing
+
+MIT-licensed open-source aquarium tools.
+Parametric designs in [OpenSCAD](https://openscad.org/) and supporting scripts.
+
+This repo continues the spirit of
+[flywheel](https://github.com/futuroptimist/flywheel),
+[sugarkube](https://github.com/futuroptimist/sugarkube), and
+[sigma](https://github.com/futuroptimist/sigma) with a focus on aquarium gear:
+- Lightweight
+- Modular
+- Reproducible
+- Open
+
+## ✨ Tools
+
+### Duckweed Scooper
+A narrow, solid-state scooper to quickly remove duckweed from planted aquariums.
+Designed to:
+- Fit into 10-gallon tanks, even with driftwood, rocks, and plants.
+- Be parametric (handle length, scoop width, wall thickness).
+- Print cleanly without supports.
+- Be extendable to mechanical designs later.
+
+File:
+[`tools/duckweed_scooper/duckweed_scooper.scad`](tools/duckweed_scooper/duckweed_scooper.scad)
+
+## 📂 Structure
+```
+aquiloop/
+├─ tools/
+│  └─ duckweed_scooper/
+│     └─ duckweed_scooper.scad
+├─ scripts/
+│  └─ build_stl.py
+├─ tests/
+│  └─ test_scad_build.py
+├─ docs/
+│  └─ prompt-docs-summary.md
+├─ .gitignore
+├─ LICENSE
+└─ README.md
+```
+
+## 🔄 Workflow
+- `scripts/build_stl.py` renders `.scad` → `.stl` with the OpenSCAD CLI.
+- CI runs linting, spellcheck, and smoke tests.
+- Contributions follow the same conventions as **flywheel**:
+  - Pre-commit hooks
+  - Prompt docs
+  - Clear commit hygiene
+
+## 🤝 Contributing
+- Fork & PR.
+- Keep designs parametric and documented.
+- Run checks before pushing:
+  ```sh
+  pre-commit run --all-files
+  pytest -q
+  ```
+
+## 📜 License
+MIT

--- a/tools/duckweed_scooper/duckweed_scooper.scad
+++ b/tools/duckweed_scooper/duckweed_scooper.scad
@@ -1,0 +1,25 @@
+// Duckweed scooper - parametric design
+// TODO: explore mechanical variant in future
+
+handle_length = 220; // mm
+handle_diameter = 10; // mm
+scooper_width = 45; // mm
+scooper_depth = 15; // mm
+wall_thickness = 2.5; // mm
+
+module handle() {
+    cylinder(h = handle_length, r = handle_diameter / 2, $fn = 64);
+}
+
+module scooper_head() {
+    difference() {
+        cube([scooper_width, scooper_depth, wall_thickness]);
+        translate([wall_thickness, wall_thickness, 0])
+            cube([scooper_width - 2 * wall_thickness,
+                  scooper_depth - 2 * wall_thickness,
+                  wall_thickness]);
+    }
+}
+
+translate([0, 0, wall_thickness]) rotate([90, 0, 0]) handle();
+translate([-scooper_width / 2, -scooper_depth, 0]) scooper_head();


### PR DESCRIPTION
## Summary
- document project scope and contribution workflow
- add parametric OpenSCAD duckweed scooper model

## Testing
- `npm run lint` (fails: ENOENT package.json)
- `npm run test:ci` (fails: ENOENT package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b14eeaf268832f931555ed434fa239